### PR TITLE
Allow inline versioning

### DIFF
--- a/Packages/com.varneon.package-exporter/Editor/ExporterWindow.cs
+++ b/Packages/com.varneon.package-exporter/Editor/ExporterWindow.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.IO;
 using System.Linq;

--- a/Packages/com.varneon.package-exporter/Editor/ExporterWindow.cs
+++ b/Packages/com.varneon.package-exporter/Editor/ExporterWindow.cs
@@ -1,4 +1,4 @@
-﻿
+
 using System;
 using System.IO;
 using System.Linq;
@@ -209,6 +209,11 @@ namespace Varneon.PackageExporter
         private bool isWindowFocused = true;
 
         private PackagePreviewDirectoryWalker packagePreviewDirectoryWalker;
+
+        /// <summary>
+        /// A string which will be replaced with the version number if included in the file name
+        /// </summary>
+        private const string VersionReplaceString = "{%v}";
 
         private struct PackagePreviewDirectoryWalker
         {
@@ -696,7 +701,12 @@ namespace Varneon.PackageExporter
         /// </summary>
         private void UpdateOutputFileName()
         {
-            fileName = $"{activeConfiguration.Name}_v{PackageVersion}";
+            if (activeConfiguration.Name.Contains(VersionReplaceString)) {
+                fileName = activeConfiguration.Name.Replace(VersionReplaceString, PackageVersion);;
+            }
+            else {
+                fileName = $"{activeConfiguration.Name}_v{PackageVersion}";
+            }
 
             packageNameField.SetValueWithoutNotify(fileName);
 


### PR DESCRIPTION
Adds the ability to replace `{%v}` with the version in the file name rather than appending the version to the file name. Appends (current behavior) if `{%v}` isn't present in the file name.